### PR TITLE
Move error messages to constants.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+    rev: v2.9.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -26,6 +26,9 @@ VALIDATE_MAX_LENGTH_ERROR = "The length of {data} exceeds the maximum allowed le
 VALIDATE_RESPONSE_TYPE_ERROR = "Expected response to be an instance of DRF Response"
 NONE_ERROR = "Mismatched content. Expected {expected} but received NoneType"
 MISSING_RESPONSE_KEY_ERROR = "The following property is missing from the tested data: {missing_key}."
+MISSING_PROPERTY_KEY_ERROR = (
+    "The following key was found in your required properties, but is missing from properties: {missing_key}"
+)
 EXCESS_RESPONSE_KEY_ERROR = (
     "The following property was found in the response, but is missing from the schema definition: {excess_key}."
 )

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -10,3 +10,24 @@ OPENAPI_PYTHON_MAPPING = {
     "number": f"{int.__name__} or {float.__name__}",
 }
 PARAMETER_CAPTURE_REGEX = re.compile(r"({[\w]+})")
+
+# Validation errors
+VALIDATE_FORMAT_ERROR = "Mismatched values, expected a value with the format {expected} but received {received}."
+VALIDATE_PATTERN_ERROR = "String '{data}' does not validate using the specified pattern: {pattern}"
+INVALID_PATTERN_ERROR = "String pattern is not valid regex: {pattern}"
+VALIDATE_ENUM_ERROR = "Mismatched values, expected a member of the enum {enum} but received {received}."
+VALIDATE_TYPE_ERROR = "Mismatched types, expected {expected} but received {received}."
+VALIDATE_MULTIPLE_OF_ERROR = "The response value {data} should be a multiple of {multiple}"
+VALIDATE_MINIMUM_ERROR = "The response value {data} exceeds the minimum allowed value of {minimum}"
+VALIDATE_MAXIMUM_ERROR = "The response value {data} exceeds the maximum allowed value of {maximum}"
+VALIDATE_MIN_LENGTH_ERROR = "The length of {data} exceeds the minimum allowed length of {min_length}"
+VALIDATE_MAX_LENGTH_ERROR = "The length of {data} exceeds the maximum allowed length of {max_length}"
+
+VALIDATE_RESPONSE_TYPE_ERROR = "Expected response to be an instance of DRF Response"
+NONE_ERROR = "Mismatched content. Expected {expected} but received NoneType"
+MISSING_RESPONSE_KEY_ERROR = "The following properties are missing from the tested data: {missing_key}."
+EXCESS_RESPONSE_KEY_ERROR = (
+    "The following properties was found in the response, but is missing from the schema definition: {excess_key}."
+)
+UNDOCUMENTED_SCHEMA_SECTION_ERROR = "Error: Unsuccessfully tried to index the OpenAPI schema by `{key}`. {error_addon}"
+ONE_OF_ERROR = "expected data to match one and only one of schema types, received {matches} matches."

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -25,9 +25,9 @@ VALIDATE_MAX_LENGTH_ERROR = "The length of {data} exceeds the maximum allowed le
 
 VALIDATE_RESPONSE_TYPE_ERROR = "Expected response to be an instance of DRF Response"
 NONE_ERROR = "Mismatched content. Expected {expected} but received NoneType"
-MISSING_RESPONSE_KEY_ERROR = "The following properties are missing from the tested data: {missing_key}."
+MISSING_RESPONSE_KEY_ERROR = "The following property is missing from the tested data: {missing_key}."
 EXCESS_RESPONSE_KEY_ERROR = (
-    "The following properties was found in the response, but is missing from the schema definition: {excess_key}."
+    "The following property was found in the response, but is missing from the schema definition: {excess_key}."
 )
 UNDOCUMENTED_SCHEMA_SECTION_ERROR = "Error: Unsuccessfully tried to index the OpenAPI schema by `{key}`. {error_addon}"
-ONE_OF_ERROR = "expected data to match one and only one of schema types, received {matches} matches."
+ONE_OF_ERROR = "Expected data to match one and only one of oneOf schema types; found {matches} matches."

--- a/openapi_tester/schema_converter.py
+++ b/openapi_tester/schema_converter.py
@@ -112,8 +112,6 @@ class SchemaToPythonConverter:
             schema_object = schema_object["oneOf"][0]
         if "properties" in schema_object:
             properties = schema_object["properties"]
-        elif "additionalProperties" in schema_object:
-            properties = {"": schema_object["additionalProperties"]}
         else:
             properties = {}
 

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -186,10 +186,7 @@ class SchemaTester:
 
     @staticmethod
     def _validate_enum(schema_section: dict, data: Any) -> Optional[str]:
-        enum = schema_section.get("enum")
-        if not enum:
-            return None
-        if data not in enum:
+        if data not in schema_section.get("enum", []):
             return (
                 f'Mismatched values, expected a member of the enum {schema_section["enum"]} but received {str(data)}.'
             )

--- a/tests/schemas/sample-schemas/external-apis/muoversi2015.e015.servizirl.it.yaml
+++ b/tests/schemas/sample-schemas/external-apis/muoversi2015.e015.servizirl.it.yaml
@@ -119,7 +119,7 @@ components:
           enum:
           - -1
           - 0
-          type: string
+          type: integer
         points:
           type: array
           items:


### PR DESCRIPTION
## Changes

- ea02a5895df90e8b3964e4052d3eedb57af92013 Creates constants for (almost) all of our error messages
- 97f47ffc5816cc8d94761521ceb8abadb416674a Changes our tests regex matching to use the constants we created
- c61b791f9dece299231bce6e1199763f899dbfff Cleans up some of the messages 
- d3d4cf7f63e9026ada7751ceee4af2f9bccd1c58 Adds minimum and maximum values handling to the schema generator 
- 83d29909a9b43ed0f2bd5ad22fc63147ecd0d1b9 Removes a pretty big chunk of code I don't think we need anymore