### PR TITLE
Add anyOf handling

### DIFF
--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -33,4 +33,5 @@ EXCESS_RESPONSE_KEY_ERROR = (
     "The following property was found in the response, but is missing from the schema definition: {excess_key}."
 )
 UNDOCUMENTED_SCHEMA_SECTION_ERROR = "Error: Unsuccessfully tried to index the OpenAPI schema by `{key}`. {error_addon}"
-ONE_OF_ERROR = "Expected data to match one and only one of oneOf schema types; found {matches} matches."
+ONE_OF_ERROR = "Expected data to match one and only one of the oneOf schema types; found {matches} matches."
+ANY_OF_ERROR = "Expected data to match one or more of the anyOf schema types, but found no matches."

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 import re
-from typing import Any, Callable, Generator, KeysView, List, Optional, Union, cast
+from typing import Any, Callable, Dict, Generator, Iterator, KeysView, List, Optional, Union, cast
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -78,13 +78,9 @@ class SchemaTester:
                 combined[key] = value
         return combined
 
-    def _combine_schemas(self, schema_sections):
-        combined_schemas = {}
+    def _combine_schemas(self, schema_sections: Union[list, tuple]) -> dict:
+        combined_schemas: Dict[str, Union[dict, list]] = {}
         for entry in schema_sections:
-            if "not" in entry:
-                # We already implicitly handle excess keys and bad types
-                # But if we don't skip not-entries the logic below will fail
-                continue
             combined_schemas = self._merge_dict(combined_schemas, entry)
         return combined_schemas
 

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -67,12 +67,13 @@ class SchemaTester:
         else:
             raise ImproperlyConfigured("No loader is configured.")
 
-    def _merge_dict(self, combined: dict, x: Any) -> dict:
+    @staticmethod
+    def _merge_dict(combined: dict, x: Any) -> dict:
         for key, value in x.items():
             if key in combined and isinstance(value, dict):
                 combined[key] = {**combined[key], **value}
             elif key in combined and isinstance(value, list):
-                combined[key] = [*combined[key], *value]
+                combined[key] = list({*combined[key], *value})
             else:
                 combined[key] = value
         return combined
@@ -95,10 +96,10 @@ class SchemaTester:
         case_tester: Optional[Callable[[str], None]] = None,
         ignore_case: Optional[List[str]] = None,
     ) -> None:
-        logger.debug("handling allOf: %s", schema_section)
-        properties = self._combine_schemas(schema_section["allOf"])
+        combined_schemas = self._combine_schemas(schema_section["allOf"])
+        logger.debug("handling allOf: %s", combined_schemas)
         self.test_schema_section(
-            schema_section={**schema_section, "type": "object", "properties": properties},
+            schema_section=combined_schemas,
             data=data,
             reference=f"{reference}.allOf",
             case_tester=case_tester,

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -235,3 +235,28 @@ def test_one_of_any_of_schemas():
             with patch.object(StaticSchemaLoader, "parameterize_path", side_effect=pass_mock_value(url_fragment)):
                 tester.validate_response(response)
                 assert sorted(tester.get_response_schema_section(response)) == sorted(schema_section)
+
+
+def test_merge_dict():
+    tester = SchemaTester()
+    test_data = [
+        {"a": {"test": 1}, "b": {"test2": 2}, "expected": {"test": 1, "test2": 2}},  # simple dict
+        {"a": {"test": [1, 2]}, "b": {"test": [2, 3]}, "expected": {"test": [1, 2, 3]}},  # dict with list and overlap
+    ]
+    for d in test_data:
+        assert tester._merge_dict(d["a"], d["b"]) == d["expected"]
+
+
+def test_not_handled_by_combine_schemas():
+    """
+    Makes sure we're able to pass allOf schemas containing the `not` keyword to the _combine_schemas method.
+    """
+    obj = {
+        "type": "object",
+        "allOf": [
+            {"properties": {"articleBody": {"type": "string"}}},
+            {"not": {"properties": {"articleBody": {"type": "integer"}}}},
+        ],
+    }
+    tester = SchemaTester()
+    tester.test_schema_section(obj, {"articleBody": "test"})

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -245,18 +245,3 @@ def test_merge_dict():
     ]
     for d in test_data:
         assert tester._merge_dict(d["a"], d["b"]) == d["expected"]
-
-
-def test_not_handled_by_combine_schemas():
-    """
-    Makes sure we're able to pass allOf schemas containing the `not` keyword to the _combine_schemas method.
-    """
-    obj = {
-        "type": "object",
-        "allOf": [
-            {"properties": {"articleBody": {"type": "string"}}},
-            {"not": {"properties": {"articleBody": {"type": "integer"}}}},
-        ],
-    }
-    tester = SchemaTester()
-    tester.test_schema_section(obj, {"articleBody": "test"})

--- a/tests/test_test_schema_section.py
+++ b/tests/test_test_schema_section.py
@@ -54,7 +54,7 @@ def test_nullable():
     for schema in example_schema_types:
         # A null value should always raise an error
         with pytest.raises(
-                DocumentationError, match=NONE_ERROR.format(expected=OPENAPI_PYTHON_MAPPING[schema["type"]])
+            DocumentationError, match=NONE_ERROR.format(expected=OPENAPI_PYTHON_MAPPING[schema["type"]])
         ):
             tester.test_schema_section(schema, None)
 
@@ -84,8 +84,8 @@ def test_wrong_type():
                 continue
 
             with pytest.raises(
-                    DocumentationError,
-                    match=VALIDATE_TYPE_ERROR.format(expected=schema_python_type, received=response_python_type),
+                DocumentationError,
+                match=VALIDATE_TYPE_ERROR.format(expected=schema_python_type, received=response_python_type),
             ):
                 tester.test_schema_section(schema, response)
 
@@ -117,7 +117,7 @@ def test_datetime():
 
     # This is invalid
     with pytest.raises(
-            DocumentationError, match=VALIDATE_FORMAT_ERROR.format(expected="date-time", received="2040-01-01 0800")
+        DocumentationError, match=VALIDATE_FORMAT_ERROR.format(expected="date-time", received="2040-01-01 0800")
     ):
         tester.test_schema_section({"type": "string", "format": "date-time"}, "2040-01-01 0800")
 
@@ -208,8 +208,8 @@ def test_response_is_missing_keys():
 def test_schema_object_is_missing_keys():
     """ Excess keys in a response should raise an error """
     with pytest.raises(
-            DocumentationError,
-            match=EXCESS_RESPONSE_KEY_ERROR.format(excess_key="value"),
+        DocumentationError,
+        match=EXCESS_RESPONSE_KEY_ERROR.format(excess_key="value"),
     ):
         schema = {"type": "object", "properties": {}}
         tester.test_schema_section(schema, example_object)
@@ -246,6 +246,41 @@ def test_anyof():
     for datum in data:
         with pytest.raises(DocumentationError, match=ANY_OF_ERROR):
             tester.test_schema_section(example_anyof_response, datum)
+
+
+docs_anyof_example = {
+    "type": "object",
+    "anyOf": [
+        {
+            "required": ["age"],
+            "properties": {
+                "age": {"type": "integer"},
+                "nickname": {"type": "string"},
+            },
+        },
+        {
+            "required": ["pet_type"],
+            "properties": {
+                "pet_type": {"type": "string", "enum": ["Cat", "Dog"]},
+                "hunts": {"type": "boolean"},
+            },
+        },
+    ],
+}
+
+
+def test_anyof_official_documentation_example():
+    """
+    This test makes sure our anyOf implementation works as described in the official example docs:
+    https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#anyof
+    """
+    tester.test_schema_section(docs_anyof_example, {"age": 50})
+    tester.test_schema_section(docs_anyof_example, {"age": 50})
+    tester.test_schema_section(docs_anyof_example, {"pet_type": "Cat", "hunts": True})
+    tester.test_schema_section(docs_anyof_example, {"nickname": "Fido", "pet_type": "Dog", "age": 44})
+
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section(docs_anyof_example, {"nickname": "Mr. Paws", "hunts": False})
 
 
 # endregion


### PR DESCRIPTION
## Changes

- Splits the allOf handler into three methods -> `handle_all_of`, `_combine_schemas`, and `_merge_dict` for reusability and easier testing
- Changed the flow of the `allOf` handler to match the flow of the `anyOf` and `oneOf` handler - this makes the base method cleaner IMO
- Updates some of our `reference` variables. We might need to do a full check to see that we're logging this appropriately. The problem here was that we weren't adding anything to the reference variable as we traversed the `anyOf`, etc. handlers
- Added a method for generating combinations of schemas, `get_all_combinations`
- Added `anyOf` handling that brute-force checks all combinations for matches before raising an error
- Added tests to exactly replicate the official docs on `anyOf`


And a final change that we can revert or improve: added some debug loggers to help debug the flow.

TODO: 

- [ ] Correct SchemaConverter to handle new allOf flow.