### PR TITLE
Update error formatting

### DIFF
--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -10,6 +10,23 @@ OPENAPI_PYTHON_MAPPING = {
     "integer": int.__name__,
     "number": f"{int.__name__} or {float.__name__}",
 }
+OPENAPI_TYPE_EXAMPLES = {
+    "boolean": True,
+    "string": "string",
+    "file": "image.jpeg",
+    "array": [],
+    "object": {},
+    "integer": 42,
+    "number": 4.2,
+}
+OPENAPI_FORMAT_EXAMPLES = {
+    "date": "2020-10-01",
+    "date-time": "2020-10-01 20:00:00",
+    "double": 2.2,
+    "float": 2.2,
+    "byte": b"bytestring",
+}
+
 PARAMETER_CAPTURE_REGEX = re.compile(r"({[\w]+})")
 
 # Validation errors

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -10,22 +10,6 @@ OPENAPI_PYTHON_MAPPING = {
     "integer": int.__name__,
     "number": f"{int.__name__} or {float.__name__}",
 }
-OPENAPI_TYPE_EXAMPLES = {
-    "boolean": True,
-    "string": "string",
-    "file": "image.jpeg",
-    "array": [],
-    "object": {},
-    "integer": 42,
-    "number": 4.2,
-}
-OPENAPI_FORMAT_EXAMPLES = {
-    "date": "2020-10-01",
-    "date-time": "2020-10-01 20:00:00",
-    "double": 2.2,
-    "float": 2.2,
-    "byte": b"bytestring",
-}
 
 PARAMETER_CAPTURE_REGEX = re.compile(r"({[\w]+})")
 

--- a/openapi_tester/exceptions.py
+++ b/openapi_tester/exceptions.py
@@ -42,9 +42,10 @@ class DocumentationError(AssertionError):
         """
         Formats and returns a standardized error message for easy debugging.
         """
+        example = json.dumps(example_item).replace('"', "")
         msg = [
             f"{message}\n\n",
-            f"Expected type: {json.dumps(example_item)}\n\n",
+            f"Expected: {example}\n\n",
             f"Received: {json.dumps(response)}\n\n",
         ]
         if hint:

--- a/openapi_tester/exceptions.py
+++ b/openapi_tester/exceptions.py
@@ -43,8 +43,8 @@ class DocumentationError(AssertionError):
         Formats and returns a standardized error message for easy debugging.
         """
         msg = [
-            f"Error: {message}\n\n",
-            f"Expected: {json.dumps(example_item)}\n\n",
+            f"{message}\n\n",
+            f"Expected type: {json.dumps(example_item)}\n\n",
             f"Received: {json.dumps(response)}\n\n",
         ]
         if hint:

--- a/openapi_tester/exceptions.py
+++ b/openapi_tester/exceptions.py
@@ -73,9 +73,9 @@ class OpenAPISchemaError(Exception):
     pass
 
 
-class UndocumentedSchemaSectionError(AssertionError):
+class UndocumentedSchemaSectionError(OpenAPISchemaError):
     """
-    Custom exception raised when we cannot find a schema section.
+    Subset of OpenAPISchemaError, raised when we cannot find a single schema section.
     """
 
     pass

--- a/openapi_tester/schema_converter.py
+++ b/openapi_tester/schema_converter.py
@@ -3,7 +3,7 @@ import random
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from openapi_tester.constants import OPENAPI_TYPE_EXAMPLES
+from openapi_tester.constants import OPENAPI_PYTHON_MAPPING
 from openapi_tester.utils import combine_sub_schemas
 
 
@@ -47,7 +47,7 @@ class SchemaToPythonConverter:
         schema_type: str = schema_object.get("type", "")
         enum: Optional[list] = schema_object.get("enum")
         if not hasattr(self, "faker"):
-            return OPENAPI_TYPE_EXAMPLES[schema_type]
+            return OPENAPI_PYTHON_MAPPING[schema_type]
         if enum:
             return enum[0]
         if schema_format and schema_type == "string":

--- a/openapi_tester/schema_converter.py
+++ b/openapi_tester/schema_converter.py
@@ -3,7 +3,7 @@ import random
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from openapi_tester.constants import OPENAPI_PYTHON_MAPPING
+from openapi_tester.constants import OPENAPI_TYPE_EXAMPLES
 from openapi_tester.utils import combine_sub_schemas
 
 
@@ -47,7 +47,7 @@ class SchemaToPythonConverter:
         schema_type: str = schema_object.get("type", "")
         enum: Optional[list] = schema_object.get("enum")
         if not hasattr(self, "faker"):
-            return OPENAPI_PYTHON_MAPPING[schema_type]
+            return OPENAPI_TYPE_EXAMPLES[schema_type]
         if enum:
             return enum[0]
         if schema_format and schema_type == "string":

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -31,7 +31,7 @@ def test_documentation_error_message():
     expected = """
 Test error message
 
-Expected type: {"key1": "str", "key2": "str", "key3": "str", "key4": ["int"]}
+Expected: {key1: str, key2: str, key3: str, key4: [int]}
 
 Received: {"key1": "test", "key2": "test", "key3": "test", "key4": [1, 2, 3]}
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -29,9 +29,9 @@ def test_documentation_error_message():
     )
 
     expected = """
-Error: Test error message
+Test error message
 
-Expected: {"key1": "string", "key2": "string", "key3": "string", "key4": [42]}
+Expected type: {"key1": "str", "key2": "str", "key3": "str", "key4": ["int"]}
 
 Received: {"key1": "test", "key2": "test", "key3": "test", "key4": [1, 2, 3]}
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -31,7 +31,7 @@ def test_documentation_error_message():
     expected = """
 Error: Test error message
 
-Expected: {"key1": "str", "key2": "str", "key3": "str", "key4": ["int"]}
+Expected: {"key1": "string", "key2": "string", "key3": "string", "key4": [42]}
 
 Received: {"key1": "test", "key2": "test", "key3": "test", "key4": [1, 2, 3]}
 

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -109,9 +109,7 @@ def test_validate_response_failure_scenario_with_predefined_data(client):
         response = client.get(item["url"])
         assert response.status_code == 200
         assert response.json() == item["expected_response"]
-        with pytest.raises(
-            DocumentationError, match="Error: The following property is missing from the tested data: width"
-        ):
+        with pytest.raises(DocumentationError, match="The following property is missing from the tested data: width"):
             tester.validate_response(response)
 
 
@@ -126,7 +124,7 @@ def test_validate_response_failure_scenario_undocumented_path(monkeypatch):
     response = response_factory(schema_section, de_parameterized_path, method, status)
     with pytest.raises(
         UndocumentedSchemaSectionError,
-        match=f"Error: Unsuccessfully tried to index the OpenAPI schema by `{parameterized_path}`.",
+        match=f"Unsuccessfully tried to index the OpenAPI schema by `{parameterized_path}`.",
     ):
         tester.validate_response(response)
 
@@ -142,7 +140,7 @@ def test_validate_response_failure_scenario_undocumented_method(monkeypatch):
     response = response_factory(schema_section, de_parameterized_path, method, status)
     with pytest.raises(
         UndocumentedSchemaSectionError,
-        match=f"Error: Unsuccessfully tried to index the OpenAPI schema by `{method}`.",
+        match=f"Unsuccessfully tried to index the OpenAPI schema by `{method}`.",
     ):
         tester.validate_response(response)
 
@@ -158,7 +156,7 @@ def test_validate_response_failure_scenario_undocumented_status_code(monkeypatch
     response = response_factory(schema_section, de_parameterized_path, method, status)
     with pytest.raises(
         UndocumentedSchemaSectionError,
-        match=f"Error: Unsuccessfully tried to index the OpenAPI schema by `{status}`.",
+        match=f"Unsuccessfully tried to index the OpenAPI schema by `{status}`.",
     ):
         tester.validate_response(response)
 

--- a/tests/test_test_schema_section.py
+++ b/tests/test_test_schema_section.py
@@ -181,7 +181,7 @@ def test_pattern():
     tester.test_schema_section(schema, "123-45-6789")
 
     # Bad pattern should fail
-    with pytest.raises(DocumentationError, match="Error: String 'test' does not validate using the specified pattern:"):
+    with pytest.raises(DocumentationError, match="String 'test' does not validate using the specified pattern:"):
         tester.test_schema_section(schema, "test")
 
     # And if we get compile errors, we need to handle this too


### PR DESCRIPTION
This 

```
---------------------------------------------------------------------------
DocumentationError                        Traceback (most recent call last)
<ipython-input-2-f8a914c30544> in <module>
----> 1 raise DocumentationError('Error message', response="1", schema={'type': 'integer'})

DocumentationError: Error: Mismatched values, expected a value with the format int but received str

Expected: "int"

Received: "1"
```

Becomes this

```
---------------------------------------------------------------------------
DocumentationError                        Traceback (most recent call last)
<ipython-input-2-f8a914c30544> in <module>
----> 1 raise DocumentationError('Error message', response="1", schema={'type': 'integer'})

DocumentationError: Mismatched values, expected a value with the format int but received str

Expected: 42

Received: "1"
```