### PR TITLE
Enable branch testing and update development status

### DIFF
--- a/openapi_tester/__init__.py
+++ b/openapi_tester/__init__.py
@@ -4,5 +4,4 @@ from .case_testers import is_camel_case, is_kebab_case, is_pascal_case, is_snake
 from .constants import OPENAPI_PYTHON_MAPPING
 from .exceptions import CaseError, DocumentationError, OpenAPISchemaError, UndocumentedSchemaSectionError
 from .loaders import BaseSchemaLoader, DrfSpectacularSchemaLoader, DrfYasgSchemaLoader, StaticSchemaLoader
-from .schema_converter import SchemaToPythonConverter
 from .schema_tester import SchemaTester

--- a/openapi_tester/loaders.py
+++ b/openapi_tester/loaders.py
@@ -110,10 +110,7 @@ class BaseSchemaLoader:
         return list({endpoint[0] for endpoint in EndpointEnumerator().get_api_endpoints()})
 
     def resolve_path(self, endpoint_path: str, method: str) -> Tuple[str, ResolverMatch]:
-        """
-        Resolves a Django path.
-        """
-
+        """ Resolves a Django path. """
         url_object = urlparse(endpoint_path)
         parsed_path = url_object.path if url_object.path.endswith("/") else url_object.path + "/"
         if not parsed_path.startswith("/"):
@@ -152,7 +149,7 @@ class BaseSchemaLoader:
         view = getattr(imported_module, view_name)
         coerced_path = BaseSchemaGenerator().coerce_path(path=path, method=method, view=view)
         pk_field_name = "".join(
-            list([entry.replace("+ ", "") for entry in difflib.Differ().compare(path, coerced_path) if "+ " in entry])
+            entry.replace("+ ", "") for entry in difflib.Differ().compare(path, coerced_path) if "+ " in entry
         )
         resolved_route.kwargs[pk_field_name] = resolved_route.kwargs["pk"]
         del resolved_route.kwargs["pk"]

--- a/openapi_tester/validators.py
+++ b/openapi_tester/validators.py
@@ -8,7 +8,6 @@ from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator, URLValidator, validate_ipv4_address, validate_ipv6_address
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 
-from openapi_tester import OpenAPISchemaError
 from openapi_tester.constants import (
     INVALID_PATTERN_ERROR,
     VALIDATE_ENUM_ERROR,
@@ -26,6 +25,7 @@ from openapi_tester.constants import (
     VALIDATE_TYPE_ERROR,
     VALIDATE_UNIQUE_ITEMS_ERROR,
 )
+from openapi_tester.exceptions import OpenAPISchemaError
 
 
 def create_validator(validation_fn: Callable, wrap_as_validator: bool = False) -> Callable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/snok/drf-openapi-tester"
 documentation = "https://github.com/snok/drf-openapi-tester"
 keywords = ["openapi", "swagger", "api", "testing", "schema", "django", "drf"]
 classifiers = [
-    "Development Status :: 4 - Beta",  # TODO: Update when stable
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: Pytest",
     "Framework :: Django",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,10 @@ max-returns = 21
 max-branches = 20
 good-names = "_,e"
 
-
 [tool.coverage.run]
 source = ["openapi_tester/*"]
 omit = ["openapi_tester/type_declarations.py"]
-branch = false
+branch = true
 
 [tool.coverage.report]
 show_missing = true

--- a/tests/schema_converter.py
+++ b/tests/schema_converter.py
@@ -11,7 +11,7 @@ from openapi_tester.utils import combine_sub_schemas
 
 class SchemaToPythonConverter:
     """
-    This class is used both by the DocumentationError format method and the various test suites.
+    This class is used by various test suites.
     """
 
     result: Any

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -28,6 +28,8 @@ def test_loader_get_route(loader):
     assert loader.resolve_path("/api/v1/snake-case", "get")[0] == "/api/{version}/snake-case/"
     assert loader.resolve_path("api/v1/snake-case/", "get")[0] == "/api/{version}/snake-case/"
     assert loader.resolve_path("api/v1/snake-case", "get")[0] == "/api/{version}/snake-case/"
+    with pytest.raises(ValueError, match="Could not resolve path `test`"):
+        assert loader.resolve_path("test", "get")
 
 
 @pytest.mark.parametrize("loader", loaders)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Generator, Optional, Tuple, Union
 import yaml
 from rest_framework.response import Response
 
-from openapi_tester.schema_converter import SchemaToPythonConverter
+from tests.schema_converter import SchemaToPythonConverter
 
 TEST_ROOT = Path(__file__).resolve(strict=True).parent
 


### PR DESCRIPTION
- Enables branch testing
- Adds a test for failing route resolving
- Updates the `development status` package metadata from beta to stable
- Moves the schema converter to the test folder now that it's exclusively used in tests. I suggest we move it back in the future if features are added where it makes sense to include it as a part of the public API.