### PR TITLE
add failing test for URLs generated by DRF router

### DIFF
--- a/test_project/api/views/names.py
+++ b/test_project/api/views/names.py
@@ -1,6 +1,6 @@
 from rest_framework.generics import RetrieveAPIView
-from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework.serializers import ModelSerializer
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from test_project.models import Names
 

--- a/test_project/api/views/names.py
+++ b/test_project/api/views/names.py
@@ -1,4 +1,5 @@
 from rest_framework.generics import RetrieveAPIView
+from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework.serializers import ModelSerializer
 
 from test_project.models import Names
@@ -17,3 +18,8 @@ class NamesRetrieveView(RetrieveAPIView):
 
     def get_object(self):
         return Names.objects.get(custom_id_field=int(self.kwargs["pk"]))
+
+
+class NameViewSet(ReadOnlyModelViewSet):
+    serializer_class = NamesSerializer
+    queryset = Names.objects.all()

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -1,8 +1,8 @@
 from django.conf.urls.i18n import i18n_patterns
-from django.urls import path
+from django.urls import include, path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
-from rest_framework import permissions
+from rest_framework import permissions, routers
 
 from test_project import views
 from test_project.api.views.animals import Animals
@@ -10,10 +10,13 @@ from test_project.api.views.cars import BadCars, GoodCars
 from test_project.api.views.exempt_endpoint import Exempt
 from test_project.api.views.i18n import Languages
 from test_project.api.views.items import Items
-from test_project.api.views.names import NamesRetrieveView
+from test_project.api.views.names import NamesRetrieveView, NameViewSet
 from test_project.api.views.snake_cased_response import SnakeCasedResponse
 from test_project.api.views.trucks import BadTrucks, GoodTrucks
 from test_project.api.views.vehicles import Vehicles
+
+router = routers.SimpleRouter()
+router.register(r"names", NameViewSet)
 
 api_urlpatterns = [
     path("api/<str:version>/cars/correct", GoodCars.as_view()),
@@ -25,8 +28,9 @@ api_urlpatterns = [
     path("api/<str:version>/items", Items.as_view()),
     path("api/<str:version>/exempt-endpoint", Exempt.as_view()),
     path("api/<str:version>/<str:pk>/names", NamesRetrieveView.as_view()),
-    # ^trailing slash is here on purpose
     path("api/<str:version>/snake-case/", SnakeCasedResponse.as_view()),
+    # ^trailing slash is here on purpose
+    path("api/<str:version>/router_generated/", include(router.urls))
 ]
 
 internationalised_urlpatterns = i18n_patterns(

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -30,7 +30,7 @@ api_urlpatterns = [
     path("api/<str:version>/<str:pk>/names", NamesRetrieveView.as_view()),
     path("api/<str:version>/snake-case/", SnakeCasedResponse.as_view()),
     # ^trailing slash is here on purpose
-    path("api/<str:version>/router_generated/", include(router.urls))
+    path("api/<str:version>/router_generated/", include(router.urls)),
 ]
 
 internationalised_urlpatterns = i18n_patterns(

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -108,6 +108,13 @@ def test_drf_coerced_model_primary_key(db, client):
     schema_tester = SchemaTester()
     schema_tester.validate_response(response)
 
+    response = client.get("/api/v1/router_generated/names/")
+    schema_tester = SchemaTester()
+    schema_tester.validate_response(response)
+    response = client.get(f"/api/v1/router_generated/names/{name.custom_id_field}/")
+    schema_tester = SchemaTester()
+    schema_tester.validate_response(response)
+
 
 @pytest.mark.parametrize(
     "filename",


### PR DESCRIPTION
As discussed in #203. URLs with coerced `pk` parameters seem to fail only when it's generated by a DRF router and `ModelViewSet`.

Looks like the problem is that the generated view name for `/api/v1/router_generated/names/{custom_id_field}/` is `"names-detail"` and does not include the package names as expected by `handle_pk_parameter()`.