### PR TITLE
Allow empty null response

### DIFF
--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -161,7 +161,7 @@ class SchemaTester:
             )
             return self.get_key_value(json_object, "schema")
 
-        if response.json():
+        if response.data and response.json():
             raise UndocumentedSchemaSectionError(
                 UNDOCUMENTED_SCHEMA_SECTION_ERROR.format(
                     key="content",
@@ -383,7 +383,7 @@ class SchemaTester:
         response_schema = self.get_response_schema_section(response)
         self.test_schema_section(
             schema_section=response_schema,
-            data=response.json(),
+            data=response.json() if response.data else {},
             case_tester=case_tester or self.case_tester,
             ignore_case=ignore_case,
             validators=validators,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drf-openapi-tester"
-version = "2.0.0"
+version = "2.0.1"
 description = "Test utility for validating OpenAPI response documentation"
 authors = ["Sondre Lillebø Gundersen <sondrelg@live.no>", "Na'aman Hirschfeld <nhirschfeld@gmail.com>"]
 maintainers = ["Na'aman Hirschfeld <nhirschfeld@gmail.com>"]

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -215,11 +215,12 @@ def test_validate_response_global_case_tester(client):
         SchemaTester(case_tester=is_pascal_case).validate_response(response=response)
 
 
-def test_validate_response_empty_content(client, monkeypatch):
+@pytest.mark.parametrize("empty_schema", [None, {}])
+def test_validate_response_empty_content(empty_schema, client, monkeypatch):
     schema = deepcopy(tester.loader.get_schema())
     del schema["paths"][parameterized_path][method]["responses"][status]["content"]
     monkeypatch.setattr(tester.loader, "get_schema", mock_schema(schema))
-    response = response_factory({}, de_parameterized_path, method, status)
+    response = response_factory(empty_schema, de_parameterized_path, method, status)
     tester.validate_response(response)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,11 +15,14 @@ if TYPE_CHECKING:
 TEST_ROOT = Path(__file__).resolve(strict=True).parent
 
 
-def response_factory(schema: dict, url_fragment: str, method: str, status_code: int | str = 200) -> Response:
-    converted_schema = SchemaToPythonConverter(deepcopy(schema)).result
+def response_factory(schema: dict | None, url_fragment: str, method: str, status_code: int | str = 200) -> Response:
+    converted_schema = None
+    if schema:
+        converted_schema = SchemaToPythonConverter(deepcopy(schema)).result
     response = Response(status=int(status_code), data=converted_schema)
     response.request = {"REQUEST_METHOD": method, "PATH_INFO": url_fragment}
-    response.json = lambda: converted_schema  # type: ignore
+    if schema:
+        response.json = lambda: converted_schema  # type: ignore
     return response
 
 


### PR DESCRIPTION
Empty response worked only if `response.json` returned something.
But if a response data is not json-serializable schema tester raises an error.