### PR TITLE
feat: add custom django testing client

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ error.
 
 ## Django testing client
 
-`OpenAPIClient` extends Django REST framework
+The library includes an `OpenAPIClient`, which extends Django REST framework's
 [`APIClient` class](https://www.django-rest-framework.org/api-guide/testing/#apiclient).
 If you wish to validate each response against OpenAPI schema when writing
 unit tests - `OpenAPIClient` is what you need!
@@ -209,7 +209,7 @@ client = OpenAPIClient(schema_tester=schema_tester)
 response = client.get('/api/v1/tests/123/')
 ```
 
-To enforce all developers working on the project to use `OpenAPIClient` simply
+To force all developers working on the project to use `OpenAPIClient` simply
 override the `client` fixture (when using `pytest-django`) or provide custom
 test cases implementation (when using standard Django `unitest`-based approach)
 and then you will be sure all newly implemented views will be validated against

--- a/README.md
+++ b/README.md
@@ -192,6 +192,29 @@ When the SchemaTester loads a schema, it runs it through
 specification compliance issues. In case of issues with the schema itself, the validator will raise the appropriate
 error.
 
+## Django testing client
+
+`OpenAPIClient` extends Django REST framework
+[`APIClient` class](https://www.django-rest-framework.org/api-guide/testing/#apiclient).
+If you wish to validate each response against OpenAPI schema when writing
+unit tests - `OpenAPIClient` is what you need!
+
+To use `OpenAPIClient` simply pass `SchemaTester` instance that should be used
+to validate responses and then use it like regular Django testing client
+(TIP: add custom fixture if you are using `pytest` to avoid code boilerplate):
+
+```python
+schema_tester = SchemaTester()
+client = OpenAPIClient(schema_tester=schema_tester)
+response = client.get('/api/v1/tests/123/')
+```
+
+To enforce all developers working on the project to use `OpenAPIClient` simply
+override the `client` fixture (when using `pytest-django`) or provide custom
+test cases implementation (when using standard Django `unitest`-based approach)
+and then you will be sure all newly implemented views will be validated against
+the OpenAPI schema.
+
 ## Known Issues
 
 * We are using [prance](https://github.com/jfinkhaeuser/prance) as a schema resolver, and it has some issues with the

--- a/README.md
+++ b/README.md
@@ -246,7 +246,10 @@ schema_tester = SchemaTester()
 
 
 class MySimpleTestCase(SimpleTestCase):
-    client_class = functools.partial(OpenAPIClient, schema_tester=schema_tester)
+    client_class = OpenAPIClient
+    # or use `functools.partial` when you want to provide custom
+    # ``SchemaTester`` instance:
+    # client_class = functools.partial(OpenAPIClient, schema_tester=schema_tester)
 ```
 
 This will ensure you all newly implemented views will be validated against

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ def client(schema_tester):
 ```
 
 If you are using plain Django test framework, we suggest to create custom
-test case implementation:
+test case implementation and use it instead of original Django one:
 
 ```python
 import functools
@@ -245,7 +245,7 @@ from openapi_tester.schema_tester import SchemaTester
 schema_tester = SchemaTester()
 
 
-class MyTestCase(SimpleTestCase):
+class MySimpleTestCase(SimpleTestCase):
     client_class = functools.partial(OpenAPIClient, schema_tester=schema_tester)
 ```
 

--- a/openapi_tester/__init__.py
+++ b/openapi_tester/__init__.py
@@ -1,16 +1,18 @@
 """ DRF OpenAPI Schema Tester """
 from .case_testers import is_camel_case, is_kebab_case, is_pascal_case, is_snake_case
+from .clients import OpenAPIClient
 from .loaders import BaseSchemaLoader, DrfSpectacularSchemaLoader, DrfYasgSchemaLoader, StaticSchemaLoader
 from .schema_tester import SchemaTester
 
 __all__ = [
+    "BaseSchemaLoader",
+    "DrfSpectacularSchemaLoader",
+    "DrfYasgSchemaLoader",
+    "SchemaTester",
+    "StaticSchemaLoader",
     "is_camel_case",
     "is_kebab_case",
     "is_pascal_case",
     "is_snake_case",
-    "BaseSchemaLoader",
-    "DrfSpectacularSchemaLoader",
-    "DrfYasgSchemaLoader",
-    "StaticSchemaLoader",
-    "SchemaTester",
+    "OpenAPIClient",
 ]

--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -1,0 +1,26 @@
+"""Subclass of ``APIClient`` using ``SchemaTester`` to validate responses."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rest_framework.test import APIClient
+
+if TYPE_CHECKING:
+    from rest_framework.response import Response
+
+    from .schema_tester import SchemaTester
+
+
+class OpenAPIClient(APIClient):
+    """``APIClient`` validating responses against OpenAPI schema."""
+
+    def __init__(self, *args, schema_tester: SchemaTester, **kwargs) -> None:
+        """Initialize ``OpenAPIClient`` instance."""
+        super().__init__(*args, **kwargs)
+        self.schema_tester = schema_tester
+
+    def request(self, **kwargs) -> Response:  # type: ignore[override]
+        """Validate fetched response against given OpenAPI schema."""
+        response = super().request(**kwargs)
+        self.schema_tester.validate_response(response)
+        return response

--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -5,22 +5,32 @@ from typing import TYPE_CHECKING
 
 from rest_framework.test import APIClient
 
+from .schema_tester import SchemaTester
+
 if TYPE_CHECKING:
     from rest_framework.response import Response
-
-    from .schema_tester import SchemaTester
 
 
 class OpenAPIClient(APIClient):
     """``APIClient`` validating responses against OpenAPI schema."""
 
-    def __init__(self, *args, schema_tester: SchemaTester, **kwargs) -> None:
+    def __init__(
+        self,
+        *args,
+        schema_tester: SchemaTester | None = None,
+        **kwargs,
+    ) -> None:
         """Initialize ``OpenAPIClient`` instance."""
         super().__init__(*args, **kwargs)
-        self.schema_tester = schema_tester
+        self.schema_tester = schema_tester or self._schema_tester_factory()
 
     def request(self, **kwargs) -> Response:  # type: ignore[override]
         """Validate fetched response against given OpenAPI schema."""
         response = super().request(**kwargs)
         self.schema_tester.validate_response(response)
         return response
+
+    @staticmethod
+    def _schema_tester_factory() -> SchemaTester:
+        """Factory of default ``SchemaTester`` instances."""
+        return SchemaTester()

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,6 +1,8 @@
+import functools
 import json
 
 import pytest
+from django.test.testcases import SimpleTestCase
 from rest_framework import status
 
 from openapi_tester.clients import OpenAPIClient
@@ -73,3 +75,20 @@ def test_request_invalid_response(
     """Ensure ``SchemaTester`` raises an exception when response is invalid."""
     with pytest.raises(**raises_kwargs):  # noqa: PT010
         openapi_client.generic(**generic_kwargs)
+
+
+def test_django_testcase_client_class():
+    """Ensure example from README.md about Django test case works fine."""
+
+    class DummyTestCase(SimpleTestCase):
+        """Django ``TestCase`` with ``OpenAPIClient`` client."""
+
+        client_class = functools.partial(
+            OpenAPIClient,
+            schema_tester=SchemaTester(),
+        )
+
+    test_case = DummyTestCase()
+    test_case._pre_setup()
+
+    assert isinstance(test_case.client, OpenAPIClient)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -15,7 +15,16 @@ def openapi_client(settings) -> OpenAPIClient:
     """Sample ``OpenAPIClient`` instance to use in tests."""
     # use `drf-yasg` schema loader in tests
     settings.INSTALLED_APPS = [app for app in settings.INSTALLED_APPS if app != "drf_spectacular"]
-    return OpenAPIClient(schema_tester=SchemaTester())
+    return OpenAPIClient()
+
+
+def test_init_schema_tester_passed():
+    """Ensure passed ``SchemaTester`` instance is used."""
+    schema_tester = SchemaTester()
+
+    client = OpenAPIClient(schema_tester=schema_tester)
+
+    assert client.schema_tester is schema_tester
 
 
 @pytest.mark.parametrize(
@@ -77,16 +86,20 @@ def test_request_invalid_response(
         openapi_client.generic(**generic_kwargs)
 
 
-def test_django_testcase_client_class():
+@pytest.mark.parametrize(
+    "openapi_client_class",
+    [
+        OpenAPIClient,
+        functools.partial(OpenAPIClient, schema_tester=SchemaTester()),
+    ],
+)
+def test_django_testcase_client_class(openapi_client_class):
     """Ensure example from README.md about Django test case works fine."""
 
     class DummyTestCase(SimpleTestCase):
         """Django ``TestCase`` with ``OpenAPIClient`` client."""
 
-        client_class = functools.partial(
-            OpenAPIClient,
-            schema_tester=SchemaTester(),
-        )
+        client_class = openapi_client_class
 
     test_case = DummyTestCase()
     test_case._pre_setup()

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,0 +1,75 @@
+import json
+
+import pytest
+from rest_framework import status
+
+from openapi_tester.clients import OpenAPIClient
+from openapi_tester.exceptions import UndocumentedSchemaSectionError
+from openapi_tester.schema_tester import SchemaTester
+
+
+@pytest.fixture()
+def openapi_client(settings) -> OpenAPIClient:
+    """Sample ``OpenAPIClient`` instance to use in tests."""
+    # use `drf-yasg` schema loader in tests
+    settings.INSTALLED_APPS = [app for app in settings.INSTALLED_APPS if app != "drf_spectacular"]
+    return OpenAPIClient(schema_tester=SchemaTester())
+
+
+@pytest.mark.parametrize(
+    ("generic_kwargs", "expected_status_code"),
+    [
+        (
+            {"method": "GET", "path": "/api/v1/cars/correct"},
+            status.HTTP_200_OK,
+        ),
+        (
+            {
+                "method": "POST",
+                "path": "/api/v1/vehicles",
+                "data": json.dumps({"vehicle_type": "suv"}),
+                "content_type": "application/json",
+            },
+            status.HTTP_201_CREATED,
+        ),
+    ],
+)
+def test_request(openapi_client, generic_kwargs, expected_status_code):
+    """Ensure ``SchemaTester`` doesn't raise exception when response valid."""
+    response = openapi_client.generic(**generic_kwargs)
+
+    assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    ("generic_kwargs", "raises_kwargs"),
+    [
+        (
+            {
+                "method": "POST",
+                "path": "/api/v1/vehicles",
+                "data": json.dumps({"vehicle_type": ("1" * 50)}),
+                "content_type": "application/json",
+            },
+            {
+                "expected_exception": UndocumentedSchemaSectionError,
+                "match": "Undocumented status code: 400",
+            },
+        ),
+        (
+            {"method": "PUT", "path": "/api/v1/animals"},
+            {
+                "expected_exception": UndocumentedSchemaSectionError,
+                "match": "Undocumented method: put",
+            },
+        ),
+    ],
+)
+def test_request_invalid_response(
+    openapi_client,
+    generic_kwargs,
+    raises_kwargs,
+):
+    """Ensure ``SchemaTester`` raises an exception when response is invalid."""
+    with pytest.raises(**raises_kwargs):  # noqa: PT010
+        openapi_client.generic(**generic_kwargs)


### PR DESCRIPTION
Introduce `OpenAPIClient` that extends `rest_framework.test.APIClient`
with responses validation against OpenAPI schema by using `SchemaTester`.

Closes #261