### PR TITLE
Fix exception when validation against empty list

### DIFF
--- a/openapi_tester/loaders.py
+++ b/openapi_tester/loaders.py
@@ -112,7 +112,7 @@ class BaseSchemaLoader:
         self.schema = self.normalize_schema_paths(de_referenced_schema)
 
     @cached_property
-    def endpoints(self) -> list[str]:  # pylint: disable=no-self-use
+    def endpoints(self) -> list[str]:
         """
         Returns a list of endpoint paths.
         """

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -143,7 +143,7 @@ class SchemaTester:
             f"Documented status codes: {list(responses_object.keys())}. ",
         )
 
-        if "openapi" not in schema:  # pylint: disable=E1135
+        if "openapi" not in schema:
             # openapi 2.0, i.e. "swagger" has a different structure than openapi 3.0 status sub-schemas
             return self.get_key_value(status_code_object, "schema")
 
@@ -383,7 +383,7 @@ class SchemaTester:
         response_schema = self.get_response_schema_section(response)
         self.test_schema_section(
             schema_section=response_schema,
-            data=response.json() if response.data else {},
+            data=response.json() if response.data is not None else {},
             case_tester=case_tester or self.case_tester,
             ignore_case=ignore_case,
             validators=validators,

--- a/test_project/api/views/names.py
+++ b/test_project/api/views/names.py
@@ -23,3 +23,8 @@ class NamesRetrieveView(RetrieveAPIView):
 class NameViewSet(ReadOnlyModelViewSet):
     serializer_class = NamesSerializer
     queryset = Names.objects.all()
+
+
+class EmptyNameViewSet(ReadOnlyModelViewSet):
+    serializer_class = NamesSerializer
+    queryset = Names.objects.all().none()

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -10,7 +10,7 @@ from test_project.api.views.cars import BadCars, GoodCars
 from test_project.api.views.exempt_endpoint import Exempt
 from test_project.api.views.i18n import Languages
 from test_project.api.views.items import Items
-from test_project.api.views.names import NamesRetrieveView, NameViewSet
+from test_project.api.views.names import EmptyNameViewSet, NamesRetrieveView, NameViewSet
 from test_project.api.views.products import Products
 from test_project.api.views.snake_cased_response import SnakeCasedResponse
 from test_project.api.views.trucks import BadTrucks, GoodTrucks
@@ -29,6 +29,7 @@ api_urlpatterns = [
     path("api/<str:version>/items", Items.as_view()),
     path("api/<str:version>/exempt-endpoint", Exempt.as_view()),
     path("api/<str:version>/<str:pk>/names", NamesRetrieveView.as_view()),
+    path("api/<str:version>/empty-names", EmptyNameViewSet.as_view({"get": "list"})),
     path("api/<str:version>/categories/<int:category_pk>/subcategories/<int:subcategory_pk>/", Products.as_view()),
     path("api/<str:version>/snake-case/", SnakeCasedResponse.as_view()),
     # ^trailing slash is here on purpose

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -52,6 +52,16 @@ def test_request(openapi_client, generic_kwargs, expected_status_code):
     assert response.status_code == expected_status_code
 
 
+def test_request_on_empty_list(openapi_client):
+    """Ensure ``SchemaTester`` doesn't raise exception when response is empty list."""
+    response = openapi_client.generic(
+        method="GET",
+        path="/api/v1/empty-names",
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_200_OK, response.data
+
+
 @pytest.mark.parametrize(
     ("generic_kwargs", "raises_kwargs"),
     [


### PR DESCRIPTION
When making a request to a list action and getting the empty list, the validator fails because it mistakenly passes an empty dict instead of the original response.