### PR TITLE
added granular check for OAS version validation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -416,7 +416,7 @@ isodate = ["isodate"]
 
 [[package]]
 name = "openapi-spec-validator"
-version = "0.4.0"
+version = "0.5.1"
 description = "OpenAPI 2.0 (aka Swagger) and OpenAPI 3.0 spec validator"
 category = "main"
 optional = false
@@ -1036,8 +1036,8 @@ openapi-schema-validator = [
     {file = "openapi_schema_validator-0.2.3-py3-none-any.whl", hash = "sha256:9bae709212a19222892cabcc60cafd903cbf4b220223f48583afa3c0e3cc6fc4"},
 ]
 openapi-spec-validator = [
-    {file = "openapi-spec-validator-0.4.0.tar.gz", hash = "sha256:97f258850afc97b048f7c2653855e0f88fa66ac103c2be5077c7960aca2ad49a"},
-    {file = "openapi_spec_validator-0.4.0-py3-none-any.whl", hash = "sha256:06900ac4d546a1df3642a779da0055be58869c598e3042a2fef067cfd99d04d0"},
+    {file = "openapi-spec-validator-0.5.1.tar.gz", hash = "sha256:8248634bad1f23cac5d5a34e193ab36e23914057ca69e91a1ede5af75552c465"},
+    {file = "openapi_spec_validator-0.5.1-py3-none-any.whl", hash = "sha256:4a8aee1e45b1ac868e07ab25e18828fe9837baddd29a8e20fdb3d3c61c8eea3d"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},


### PR DESCRIPTION
In relation to [this issue](https://github.com/snok/drf-openapi-tester/issues/271) where an open api spec with version 3.0.1 was failing validation.

Left out the existing code causing failure in pre-commit checks. 

