### PR TITLE
Trailing slash in parametrized path

### DIFF
--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -1,7 +1,6 @@
 """ Schema Tester """
 from __future__ import annotations
 
-import re
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Callable, cast
 
@@ -90,16 +89,11 @@ class SchemaTester:
             raise ImproperlyConfigured(INIT_ERROR)
 
     @staticmethod
-    def get_key_value(schema: dict[str, dict], key: str, error_addon: str = "", use_regex=False) -> dict:
+    def get_key_value(schema: dict[str, dict], key: str, error_addon: str = "") -> dict:
         """
         Returns the value of a given key
         """
         try:
-            if use_regex:
-                compiled_pattern = re.compile(key)
-                for key_ in schema.keys():
-                    if compiled_pattern.match(key_):
-                        return schema[key_]
             return schema[key]
         except KeyError as e:
             raise UndocumentedSchemaSectionError(
@@ -174,10 +168,9 @@ class SchemaTester:
             )
             json_object = self.get_key_value(
                 content_object,
-                r"^application\/.*json$",
+                "application/json",
                 "\n\nNo `application/json` responses documented for method: "
                 f"{response_method}, path: {parameterized_path}",
-                use_regex=True,
             )
             return self.get_key_value(json_object, "schema")
 

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -177,7 +177,7 @@ class SchemaTester:
                 r"^application\/.*json$",
                 "\n\nNo `application/json` responses documented for method: "
                 f"{response_method}, path: {parameterized_path}",
-                use_regex=True
+                use_regex=True,
             )
             return self.get_key_value(json_object, "schema")
 

--- a/test_project/api/views/pets.py
+++ b/test_project/api/views/pets.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rest_framework.response import Response
+from rest_framework.status import HTTP_200_OK
+from rest_framework.views import APIView
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
+
+
+class Pet(APIView):
+    def get(self, request: Request, petId: int) -> Response:
+        pet = {"name": "doggie", "category": {"id": 1, "name": "Dogs"}, "photoUrls": [], "status": "available"}
+        return Response(pet, HTTP_200_OK)

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls.i18n import i18n_patterns
-from django.urls import include, path
+from django.urls import include, path, re_path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions, routers
@@ -11,6 +11,7 @@ from test_project.api.views.exempt_endpoint import Exempt
 from test_project.api.views.i18n import Languages
 from test_project.api.views.items import Items
 from test_project.api.views.names import EmptyNameViewSet, NamesRetrieveView, NameViewSet
+from test_project.api.views.pets import Pet
 from test_project.api.views.products import Products
 from test_project.api.views.snake_cased_response import SnakeCasedResponse
 from test_project.api.views.trucks import BadTrucks, GoodTrucks
@@ -34,6 +35,7 @@ api_urlpatterns = [
     path("api/<str:version>/snake-case/", SnakeCasedResponse.as_view()),
     # ^trailing slash is here on purpose
     path("api/<str:version>/router_generated/", include(router.urls)),
+    re_path(r"api/pet/(?P<petId>\d+)", Pet.as_view(), name="get-pet"),
 ]
 
 internationalised_urlpatterns = i18n_patterns(

--- a/tests/schemas/sample-schemas/content_types.yaml
+++ b/tests/schemas/sample-schemas/content_types.yaml
@@ -38,7 +38,7 @@ tags:
   - name: user
     description: Operations about user
 paths:
-  /api/pet/:
+  /api/pet:
     put:
       tags:
         - pet
@@ -48,7 +48,7 @@ paths:
       requestBody:
         description: Update an existent pet in the store
         content:
-          application/vnd.api+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/Pet'
           application/xml:
@@ -62,7 +62,7 @@ paths:
         '200':
           description: Successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
             application/xml:
@@ -87,7 +87,7 @@ paths:
       requestBody:
         description: Create a new pet in the store
         content:
-          application/vnd.api+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/Pet'
           application/xml:
@@ -101,7 +101,7 @@ paths:
         '200':
           description: Successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
             application/xml:
@@ -113,7 +113,7 @@ paths:
         - petstore_auth:
             - write:pets
             - read:pets
-  /api/pet/findByStatus/:
+  /api/pet/findByStatus:
     get:
       tags:
         - pet
@@ -137,7 +137,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 type: array
                 items:
@@ -153,7 +153,7 @@ paths:
         - petstore_auth:
             - write:pets
             - read:pets
-  /api/pet/findByTags/:
+  /api/pet/findByTags:
     get:
       tags:
         - pet
@@ -174,7 +174,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 type: array
                 items:
@@ -190,7 +190,7 @@ paths:
         - petstore_auth:
             - write:pets
             - read:pets
-  /api/pet/{petId}/:
+  /api/pet/{petId}:
     get:
       tags:
         - pet
@@ -209,7 +209,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
             application/xml:
@@ -282,7 +282,7 @@ paths:
         - petstore_auth:
             - write:pets
             - read:pets
-  /api/pet/{petId}/uploadImage/:
+  /api/pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -313,14 +313,14 @@ paths:
         '200':
           description: successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
             - write:pets
             - read:pets
-  /api/store/inventory/:
+  /api/store/inventory:
     get:
       tags:
         - store
@@ -331,7 +331,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 type: object
                 additionalProperties:
@@ -339,7 +339,7 @@ paths:
                   format: int32
       security:
         - api_key: []
-  /api/store/order/:
+  /api/store/order:
     post:
       tags:
         - store
@@ -348,7 +348,7 @@ paths:
       operationId: placeOrder
       requestBody:
         content:
-          application/vnd.api+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/Order'
           application/xml:
@@ -361,12 +361,12 @@ paths:
         '200':
           description: successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Order'
         '405':
           description: Invalid input
-  /api/store/order/{orderId}/:
+  /api/store/order/{orderId}:
     get:
       tags:
         - store
@@ -385,7 +385,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Order'
             application/xml:
@@ -414,7 +414,7 @@ paths:
           description: Invalid ID supplied
         '404':
           description: Order not found
-  /api/user/:
+  /api/user:
     post:
       tags:
         - user
@@ -424,7 +424,7 @@ paths:
       requestBody:
         description: Created user object
         content:
-          application/vnd.api+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/User'
           application/xml:
@@ -437,13 +437,13 @@ paths:
         default:
           description: successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/User'
             application/xml:
               schema:
                 $ref: '#/components/schemas/User'
-  /api/user/createWithList/:
+  /api/user/createWithList:
     post:
       tags:
         - user
@@ -452,7 +452,7 @@ paths:
       operationId: createUsersWithListInput
       requestBody:
         content:
-          application/vnd.api+json:
+          application/json:
             schema:
               type: array
               items:
@@ -461,7 +461,7 @@ paths:
         '200':
           description: Successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/User'
             application/xml:
@@ -469,7 +469,7 @@ paths:
                 $ref: '#/components/schemas/User'
         default:
           description: successful operation
-  /api/user/login/:
+  /api/user/login:
     get:
       tags:
         - user
@@ -507,12 +507,12 @@ paths:
             application/xml:
               schema:
                 type: string
-            application/vnd.api+json:
+            application/json:
               schema:
                 type: string
         '400':
           description: Invalid username/password supplied
-  /api/user/logout/:
+  /api/user/logout:
     get:
       tags:
         - user
@@ -523,7 +523,7 @@ paths:
       responses:
         default:
           description: successful operation
-  /api/user/{username}/:
+  /api/user/{username}:
     get:
       tags:
         - user
@@ -541,7 +541,7 @@ paths:
         '200':
           description: successful operation
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/User'
             application/xml:
@@ -567,7 +567,7 @@ paths:
       requestBody:
         description: Update an existent user in the store
         content:
-          application/vnd.api+json:
+          application/json:
             schema:
               $ref: '#/components/schemas/User'
           application/xml:
@@ -773,7 +773,7 @@ components:
     Pet:
       description: Pet object that needs to be added to the store
       content:
-        application/vnd.api+json:
+        application/json:
           schema:
             $ref: '#/components/schemas/Pet'
         application/xml:
@@ -782,7 +782,7 @@ components:
     UserArray:
       description: List of user object
       content:
-        application/vnd.api+json:
+        application/json:
           schema:
             type: array
             items:

--- a/tests/schemas/sample-schemas/content_types.yaml
+++ b/tests/schemas/sample-schemas/content_types.yaml
@@ -1,0 +1,802 @@
+openapi: 3.0.3
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
+    Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+    You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+    That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+
+    _If you're looking for the Swagger 2.0/OAS 2.0 version of Petstore, then click [here](https://editor.swagger.io/?url=https://petstore.swagger.io/v2/swagger.yaml). Alternatively, you can load via the `Edit > Load Petstore OAS 2.0` menu option!_
+
+    Some useful links:
+    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.11
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore3.swagger.io/api/v3
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
+paths:
+  /api/pet/:
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: Update an existing pet by Id
+      operationId: updatePet
+      requestBody:
+        description: Update an existent pet in the store
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Pet'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: Add a new pet to the store
+      operationId: addPet
+      requestBody:
+        description: Create a new pet in the store
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Pet'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /api/pet/findByStatus/:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: false
+          explode: true
+          schema:
+            type: string
+            default: available
+            enum:
+              - available
+              - pending
+              - sold
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /api/pet/findByTags/:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /api/pet/{petId}/:
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - api_key: []
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: name
+          in: query
+          description: Name of pet that needs to be updated
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Status of pet that needs to be updated
+          schema:
+            type: string
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: delete a pet
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          description: ''
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /api/pet/{petId}/uploadImage/:
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: additionalMetadata
+          in: query
+          description: Additional Metadata
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /api/store/inventory/:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /api/store/order/:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: Place a new order in the store
+      operationId: placeOrder
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/Order'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Order'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Order'
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '405':
+          description: Invalid input
+  /api/store/order/{orderId}/:
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of order that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+  /api/user/:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      requestBody:
+        description: Created user object
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        default:
+          description: successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+  /api/user/createWithList/:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: Creates list of users with given input array
+      operationId: createUsersWithListInput
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/User'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+        default:
+          description: successful operation
+  /api/user/login/:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: false
+          schema:
+            type: string
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/vnd.api+json:
+              schema:
+                type: string
+        '400':
+          description: Invalid username/password supplied
+  /api/user/logout/:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+  /api/user/{username}/:
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: 'The name that needs to be fetched. Use user1 for testing. '
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Update user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be deleted
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Update an existent user in the store
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        default:
+          description: successful operation
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        petId:
+          type: integer
+          format: int64
+          example: 198772
+        quantity:
+          type: integer
+          format: int32
+          example: 7
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          example: approved
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+      xml:
+        name: order
+    Customer:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 100000
+        username:
+          type: string
+          example: fehguy
+        address:
+          type: array
+          xml:
+            name: addresses
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Address'
+      xml:
+        name: customer
+    Address:
+      type: object
+      properties:
+        street:
+          type: string
+          example: 437 Lytton
+        city:
+          type: string
+          example: Palo Alto
+        state:
+          type: string
+          example: CA
+        zip:
+          type: string
+          example: '94301'
+      xml:
+        name: address
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Dogs
+      xml:
+        name: category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        username:
+          type: string
+          example: theUser
+        firstName:
+          type: string
+          example: John
+        lastName:
+          type: string
+          example: James
+        email:
+          type: string
+          example: john@email.com
+        password:
+          type: string
+          example: '12345'
+        phone:
+          type: string
+          example: '12345'
+        userStatus:
+          type: integer
+          description: User Status
+          format: int32
+          example: 1
+      xml:
+        name: user
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: tag
+    Pet:
+      required:
+        - name
+        - photoUrls
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        category:
+          $ref: '#/components/schemas/Category'
+        photoUrls:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            type: string
+            xml:
+              name: photoUrl
+        tags:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+      xml:
+        name: '##default'
+  requestBodies:
+    Pet:
+      description: Pet object that needs to be added to the store
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+    UserArray:
+      description: List of user object
+      content:
+        application/vnd.api+json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://petstore3.swagger.io/oauth/authorize
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/tests/test_django_framework.py
+++ b/tests/test_django_framework.py
@@ -17,8 +17,8 @@ class BaseAPITestCase(APITestCase):
         schema_tester.validate_response(response=response, **kwargs)
 
 
-class TeamsAPITests(BaseAPITestCase):
-    def test_schema_using_assert_response(self):
+class PetsAPITests(BaseAPITestCase):
+    def test_get_pet_by_id(self):
         response = self.client.get(
             reverse(
                 "get-pet",

--- a/tests/test_django_framework.py
+++ b/tests/test_django_framework.py
@@ -1,0 +1,32 @@
+from django.urls import reverse
+from rest_framework.response import Response
+from rest_framework.test import APITestCase
+
+from openapi_tester import SchemaTester
+from tests.utils import TEST_ROOT
+
+schema_tester = SchemaTester(schema_file_path=str(TEST_ROOT) + "/schemas/sample-schemas/content_types.yaml")
+
+
+class BaseAPITestCase(APITestCase):
+    """Base test class for api views including schema validation"""
+
+    @staticmethod
+    def assertResponse(response: Response, **kwargs) -> None:
+        """helper to run validate_response and pass kwargs to it"""
+        schema_tester.validate_response(response=response, **kwargs)
+
+
+class TeamsAPITests(BaseAPITestCase):
+    def test_schema_using_assert_response(self):
+        response = self.client.get(
+            reverse(
+                "get-pet",
+                kwargs={
+                    "petId": 1,
+                },
+            ),
+            content_type="application/vnd.api+json",
+        )
+        assert response.status_code == 200
+        self.assertResponse(response)


### PR DESCRIPTION
This branch is based on https://github.com/snok/drf-openapi-tester/pull/284 that has the required drf setup to show where this is failing.

I have removed the trailing slash on paths in `/drf-openapi-tester/tests/schemas/sample-schemas/content_types.yaml` to represent our OAS defined paths.

This reproduces the error we are seeing, where the **Undocumented route** parametrized path has a trailing slash:
```
schema = {'/api/pet': {'post': {'description': 'Add a new pet to the store', 'operationId': 'addPet', 'requestBody': {'content'..., 'name': 'status', 'schema': {'type': 'string'}}], 'responses': {'405': {'description': 'Invalid input'}}, ...}}, ...}
key = '/api/pet/{petId}/'
error_addon = '\n\nUndocumented route /api/pet/{petId}/.\n\nDocumented routes: /api/pet\n\t• /api/pet/findByStatus\n\t• /api/pet/fin...rId}\n\t• /api/user\n\t• /api/user/createWithList\n\t• /api/user/login\n\t• /api/user/logout\n\t• /api/user/{username}'

    @staticmethod
    def get_key_value(schema: dict[str, dict], key: str, error_addon: str = "") -> dict:
        """
        Returns the value of a given key
        """
        try:
            return schema[key]
        except KeyError as e:
>           raise UndocumentedSchemaSectionError(
                UNDOCUMENTED_SCHEMA_SECTION_ERROR.format(key=key, error_addon=error_addon)
            ) from e
E           openapi_tester.exceptions.UndocumentedSchemaSectionError: Error: Unsuccessfully tried to index the OpenAPI schema by `/api/pet/{petId}/`. 
E           
E           Undocumented route /api/pet/{petId}/.
E           
E           Documented routes: /api/pet
E               • /api/pet/findByStatus
E               • /api/pet/findByTags
E               • /api/pet/{petId}
E               • /api/pet/{petId}/uploadImage
E               • /api/store/inventory
E               • /api/store/order
E               • /api/store/order/{orderId}
E               • /api/user
E               • /api/user/createWithList
E               • /api/user/login
E               • /api/user/logout
E               • /api/user/{username}

openapi_tester/schema_tester.py:99: UndocumentedSchemaSectionError
```

Removing `+ "/" ` from this line of code solves the issue for us, and is part of the discussion from [this](https://github.com/snok/drf-openapi-tester/issues/264) issue: 
```
File: third_party/drf-openapi-tester/openapi_tester/loaders.py
146:         parsed_path = url_object.path if url_object.path.endswith("/") else url_object.path + "/"

```