### PR TITLE
Check anyOf and oneOf schemas in nullable validation

### DIFF
--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -239,6 +239,20 @@ class SchemaTester:
         """
         openapi_schema_3_nullable = "nullable"
         swagger_2_nullable = "x-nullable"
+        if "oneOf" in schema_item:
+            one_of: list[dict[str, Any]] = schema_item.get("oneOf", [])
+            return any(
+                nullable_key in schema and schema[nullable_key]
+                for schema in one_of
+                for nullable_key in [openapi_schema_3_nullable, swagger_2_nullable]
+            )
+        if "anyOf" in schema_item:
+            any_of: list[dict[str, Any]] = schema_item.get("anyOf", [])
+            return any(
+                nullable_key in schema and schema[nullable_key]
+                for schema in any_of
+                for nullable_key in [openapi_schema_3_nullable, swagger_2_nullable]
+            )
         return any(
             nullable_key in schema_item and schema_item[nullable_key]
             for nullable_key in [openapi_schema_3_nullable, swagger_2_nullable]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -310,3 +310,17 @@ def test_byte_validation():
 
     with pytest.raises(DocumentationError):
         tester.test_schema_section({"type": "string", "format": "byte"}, "test123")
+
+
+def test_is_nullable_anyof():
+    tester.test_schema_section({"anyOf": [{"type": "object", "nullable": True}, {"type": "string"}]}, None)
+
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section({"anyOf": [{"type": "object"}, {"type": "string"}]}, None)
+
+
+def test_is_nullable_oneof():
+    tester.test_schema_section({"oneOf": [{"type": "object", "nullable": True}, {"type": "string"}]}, None)
+
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section({"oneOf": [{"type": "object"}, {"type": "string"}]}, None)


### PR DESCRIPTION
`test_is_nullable()` is executed before the normal `test_schema_section()` processing, including the `anyOf` and `oneOf` checking, takes place, and if your `nullable` definition comes from inside either `anyOf` or `oneOf`, the validation will fail.