### PR TITLE
feat: adding support for request validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ from openapi_tester import SchemaTester
 schema_tester = SchemaTester(schema_file_path="./schemas/publishedSpecs.yaml")
 ```
 
-Once you've instantiated a tester, you can use it to test responses:
+Once you've instantiated a tester, you can use it to test responses and request bodies:
 
 ```python
 from openapi_tester.schema_tester import SchemaTester
@@ -53,6 +53,12 @@ def test_response_documentation(client):
     response = client.get('api/v1/test/1')
     assert response.status_code == 200
     schema_tester.validate_response(response=response)
+
+
+def test_request_documentation(client):
+    response = client.get('api/v1/test/1')
+    assert response.status_code == 200
+    schema_tester.validate_request(response=response)
 ```
 
 If you are using the Django testing framework, you can create a base `APITestCase` that incorporates schema validation:
@@ -188,11 +194,11 @@ In case of issues with the schema itself, the validator will raise the appropria
 
 The library includes an `OpenAPIClient`, which extends Django REST framework's
 [`APIClient` class](https://www.django-rest-framework.org/api-guide/testing/#apiclient).
-If you wish to validate each response against OpenAPI schema when writing
+If you wish to validate each request and response against OpenAPI schema when writing
 unit tests - `OpenAPIClient` is what you need!
 
 To use `OpenAPIClient` simply pass `SchemaTester` instance that should be used
-to validate responses and then use it like regular Django testing client:
+to validate requests and responses and then use it like regular Django testing client:
 
 ```python
 schema_tester = SchemaTester()

--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -27,8 +27,14 @@ class OpenAPIClient(APIClient):
     def request(self, **kwargs) -> Response:  # type: ignore[override]
         """Validate fetched response against given OpenAPI schema."""
         response = super().request(**kwargs)
+        if self._is_successful_response(response):
+            self.schema_tester.validate_request(response)
         self.schema_tester.validate_response(response)
         return response
+
+    @staticmethod
+    def _is_successful_response(response: Response) -> bool:
+        return response.status_code < 400
 
     @staticmethod
     def _schema_tester_factory() -> SchemaTester:

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -15,9 +15,9 @@ VALIDATE_PATTERN_ERROR = 'The string "{data}" does not match the specified patte
 INVALID_PATTERN_ERROR = "String pattern is not valid regex: {pattern}"
 VALIDATE_ENUM_ERROR = "Expected: a member of the enum {enum}\n\nReceived: {received}"
 VALIDATE_TYPE_ERROR = 'Expected: {article} "{type}" type value\n\nReceived: {received}'
-VALIDATE_MULTIPLE_OF_ERROR = "The response value {data} should be a multiple of {multiple}"
-VALIDATE_MINIMUM_ERROR = "The response value {data} is lower than the specified minimum of {minimum}"
-VALIDATE_MAXIMUM_ERROR = "The response value {data} exceeds the maximum allowed value of {maximum}"
+VALIDATE_MULTIPLE_OF_ERROR = "The value {data} should be a multiple of {multiple}"
+VALIDATE_MINIMUM_ERROR = "The value {data} is lower than the specified minimum of {minimum}"
+VALIDATE_MAXIMUM_ERROR = "The value {data} exceeds the maximum allowed value of {maximum}"
 VALIDATE_MIN_LENGTH_ERROR = 'The length of "{data}" is shorter than the specified minimum length of {min_length}'
 VALIDATE_MAX_LENGTH_ERROR = 'The length of "{data}" exceeds the specified maximum length of {max_length}'
 VALIDATE_MIN_ARRAY_LENGTH_ERROR = (
@@ -32,9 +32,9 @@ VALIDATE_MAXIMUM_NUMBER_OF_PROPERTIES_ERROR = (
 )
 VALIDATE_UNIQUE_ITEMS_ERROR = "The array {data} must contain unique items only"
 VALIDATE_NONE_ERROR = "Received a null value for a non-nullable schema object"
-VALIDATE_MISSING_RESPONSE_KEY_ERROR = 'The following property is missing in the response data: "{missing_key}"'
-VALIDATE_EXCESS_RESPONSE_KEY_ERROR = (
-    'The following property was found in the response, but is missing from the schema definition: "{excess_key}"'
+VALIDATE_MISSING_KEY_ERROR = 'The following property is missing in the {http_message} data: "{missing_key}"'
+VALIDATE_EXCESS_KEY_ERROR = (
+    'The following property was found in the {http_message}, but is missing from the schema definition: "{excess_key}"'
 )
 VALIDATE_WRITE_ONLY_RESPONSE_KEY_ERROR = (
     'The following property was found in the response, but is documented as being "writeOnly": "{write_only_key}"'

--- a/openapi_tester/loaders.py
+++ b/openapi_tester/loaders.py
@@ -129,6 +129,7 @@ class BaseSchemaLoader:
         """
         de_referenced_schema = self.de_reference_schema(schema)
         self.validate_schema(de_referenced_schema)
+
         self.schema = self.normalize_schema_paths(de_referenced_schema)
 
     @cached_property
@@ -245,6 +246,7 @@ class StaticSchemaLoader(BaseSchemaLoader):
 
     def __init__(self, path: str, field_key_map: dict[str, str] | None = None):
         super().__init__(field_key_map=field_key_map)
+
         self.path = path if not isinstance(path, pathlib.PosixPath) else str(path)
 
     def load_schema(self) -> dict[str, Any]:

--- a/test_project/api/serializers.py
+++ b/test_project/api/serializers.py
@@ -8,6 +8,11 @@ class VehicleSerializer(serializers.Serializer):
     vehicle_type = serializers.CharField(max_length=10)
 
 
+class PetsSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=254)
+    tag = serializers.CharField(max_length=254, required=False)
+
+
 class ItemSerializer(serializers.Serializer):
     item_type = serializers.CharField(max_length=10)
 

--- a/test_project/api/views/pets.py
+++ b/test_project/api/views/pets.py
@@ -6,6 +6,8 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
 from rest_framework.views import APIView
 
+from test_project.api.serializers import PetsSerializer
+
 if TYPE_CHECKING:
     from rest_framework.request import Request
 
@@ -14,3 +16,8 @@ class Pet(APIView):
     def get(self, request: Request, petId: int) -> Response:
         pet = {"name": "doggie", "category": {"id": 1, "name": "Dogs"}, "photoUrls": [], "status": "available"}
         return Response(pet, HTTP_200_OK)
+
+    def post(self, request) -> Response:
+        serializer = PetsSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return Response({"id": 1, "name": request.data["name"]}, 201)

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -35,6 +35,7 @@ api_urlpatterns = [
     path("api/<str:version>/snake-case/", SnakeCasedResponse.as_view()),
     # ^trailing slash is here on purpose
     path("api/<str:version>/router_generated/", include(router.urls)),
+    path("api/pets", Pet.as_view(), name="get-pets"),
     re_path(r"api/pet/(?P<petId>\d+)", Pet.as_view(), name="get-pet"),
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING, Callable
+from unittest.mock import MagicMock
+
+import pytest
+from rest_framework.response import Response
+
+from tests.schema_converter import SchemaToPythonConverter
+from tests.utils import TEST_ROOT
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture()
+def pets_api_schema() -> Path:
+    return TEST_ROOT / "schemas" / "openapi_v3_reference_schema.yaml"
+
+
+@pytest.fixture()
+def pets_post_request():
+    request_body = MagicMock()
+    request_body.read.return_value = b'{"name": "doggie", "tag": "dog"}'
+    return {
+        "PATH_INFO": "/api/pets",
+        "REQUEST_METHOD": "POST",
+        "SERVER_PORT": "80",
+        "wsgi.url_scheme": "http",
+        "CONTENT_LENGTH": "70",
+        "CONTENT_TYPE": "application/json",
+        "wsgi.input": request_body,
+        "QUERY_STRING": "",
+    }
+
+
+@pytest.fixture()
+def invalid_pets_post_request():
+    request_body = MagicMock()
+    request_body.read.return_value = b'{"surname": "doggie", "species": "dog"}'
+    return {
+        "PATH_INFO": "/api/pets",
+        "REQUEST_METHOD": "POST",
+        "SERVER_PORT": "80",
+        "wsgi.url_scheme": "http",
+        "CONTENT_LENGTH": "70",
+        "CONTENT_TYPE": "application/json",
+        "wsgi.input": request_body,
+        "QUERY_STRING": "",
+    }
+
+
+@pytest.fixture()
+def response_factory() -> Callable:
+    def response(
+        schema: dict | None,
+        url_fragment: str,
+        method: str,
+        status_code: int | str = 200,
+        response_body: dict | None = None,
+    ) -> Response:
+        converted_schema = None
+        if schema:
+            converted_schema = SchemaToPythonConverter(deepcopy(schema)).result
+        response = Response(status=int(status_code), data=converted_schema)
+        response.request = {"REQUEST_METHOD": method, "PATH_INFO": url_fragment}  # type: ignore
+        if schema:
+            response.json = lambda: converted_schema  # type: ignore
+        elif response_body:
+            response.request["CONTENT_LENGTH"] = len(response_body)  # type: ignore
+            response.request["CONTENT_TYPE"] = "application/json"  # type: ignore
+            response.request["wsgi.input"] = response_body  # type: ignore
+            response.renderer_context = {"request": MagicMock(data=response_body)}  # type: ignore
+        return response
+
+    return response

--- a/tests/schemas/openapi_v3_reference_schema.yaml
+++ b/tests/schemas/openapi_v3_reference_schema.yaml
@@ -12,9 +12,9 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: http://petstore.swagger.io/api
+  - url: http://petstore.swagger.io
 paths:
-  /pets:
+  /api/pets:
     get:
       description: |
         Returns all pets from the system that the user has access to
@@ -65,19 +65,31 @@ paths:
             schema:
               $ref: '#/components/schemas/NewPet'
       responses:
-        '200':
+        '201':
           description: pet response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                additionalProperties: true
         default:
           description: unexpected error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /pets/{id}:
+  /api/pets/{id}:
     get:
       description: Returns a user based on a single ID, if the user does not have access to the pet
       operationId: find pet by id

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,6 +2,7 @@ import pytest
 
 from openapi_tester import SchemaTester
 from openapi_tester.exceptions import CaseError, DocumentationError
+from openapi_tester.schema_tester import OpenAPITestConfig
 from openapi_tester.validators import (
     validate_enum,
     validate_format,
@@ -62,29 +63,29 @@ class TestValidatorErrors:
 
     def test_validate_minimum_error(self):
         message = validate_minimum({"minimum": 2}, 0)
-        assert message == "The response value 0 is lower than the specified minimum of 2"
+        assert message == "The value 0 is lower than the specified minimum of 2"
 
     def test_validate_exclusive_minimum_error(self):
         message = validate_minimum({"minimum": 2, "exclusiveMinimum": True}, 2)
-        assert message == "The response value 2 is lower than the specified minimum of 3"
+        assert message == "The value 2 is lower than the specified minimum of 3"
 
         message = validate_minimum({"minimum": 2, "exclusiveMinimum": False}, 2)
         assert message is None
 
     def test_validate_maximum_error(self):
         message = validate_maximum({"maximum": 2}, 3)
-        assert message == "The response value 3 exceeds the maximum allowed value of 2"
+        assert message == "The value 3 exceeds the maximum allowed value of 2"
 
     def test_validate_exclusive_maximum_error(self):
         message = validate_maximum({"maximum": 2, "exclusiveMaximum": True}, 2)
-        assert message == "The response value 2 exceeds the maximum allowed value of 1"
+        assert message == "The value 2 exceeds the maximum allowed value of 1"
 
         message = validate_maximum({"maximum": 2, "exclusiveMaximum": False}, 2)
         assert message is None
 
     def test_validate_multiple_of_error(self):
         message = validate_multiple_of({"multipleOf": 2}, 3)
-        assert message == "The response value 3 should be a multiple of 2"
+        assert message == "The value 3 should be a multiple of 2"
 
     def test_validate_pattern_error(self):
         message = validate_pattern({"pattern": "^[a-z]$"}, "3")
@@ -159,7 +160,9 @@ class TestTestOpenAPIObjectErrors:
         tester = SchemaTester()
         with pytest.raises(DocumentationError, match=expected_error_message):
             tester.test_openapi_object(
-                {"required": ["one"], "properties": {"one": {"type": "int"}}}, {"two": 2}, reference="init"
+                {"required": ["one"], "properties": {"one": {"type": "int"}}},
+                {"two": 2},
+                OpenAPITestConfig(reference="init"),
             )
 
     def test_missing_schema_key_error(self):
@@ -171,7 +174,9 @@ class TestTestOpenAPIObjectErrors:
         tester = SchemaTester()
         with pytest.raises(DocumentationError, match=expected_error_message):
             tester.test_openapi_object(
-                {"required": ["one"], "properties": {"one": {"type": "int"}}}, {"one": 1, "two": 2}, reference="init"
+                {"required": ["one"], "properties": {"one": {"type": "int"}}},
+                {"one": 1, "two": 2},
+                OpenAPITestConfig(reference="init"),
             )
 
     def test_key_in_write_only_properties_error(self):
@@ -185,7 +190,7 @@ class TestTestOpenAPIObjectErrors:
             tester.test_openapi_object(
                 {"properties": {"one": {"type": "int", "writeOnly": True}}},
                 {"one": 1},
-                reference="init",
+                OpenAPITestConfig(reference="init"),
             )
 
 
@@ -197,7 +202,7 @@ def test_null_error():
     )
     tester = SchemaTester()
     with pytest.raises(DocumentationError, match=expected_error_message):
-        tester.test_schema_section({"type": "object"}, None, reference="init")
+        tester.test_schema_section({"type": "object"}, None, OpenAPITestConfig(reference="init"))
 
 
 def test_any_of_error():
@@ -207,7 +212,7 @@ def test_any_of_error():
     )
     tester = SchemaTester()
     with pytest.raises(DocumentationError, match=expected_error_message):
-        tester.test_schema_section({"anyOf": []}, {}, reference="init")
+        tester.test_schema_section({"anyOf": []}, {}, OpenAPITestConfig(reference="init"))
 
 
 def test_one_of_error():
@@ -216,4 +221,4 @@ def test_one_of_error():
     )
     tester = SchemaTester()
     with pytest.raises(DocumentationError, match=expected_error_message):
-        tester.test_schema_section({"oneOf": []}, {}, reference="init")
+        tester.test_schema_section({"oneOf": []}, {}, OpenAPITestConfig(reference="init"))

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -9,7 +9,7 @@ from faker import Faker
 from openapi_tester import SchemaTester
 from openapi_tester.constants import (
     OPENAPI_PYTHON_MAPPING,
-    VALIDATE_EXCESS_RESPONSE_KEY_ERROR,
+    VALIDATE_EXCESS_KEY_ERROR,
     VALIDATE_MAX_ARRAY_LENGTH_ERROR,
     VALIDATE_MAX_LENGTH_ERROR,
     VALIDATE_MAXIMUM_ERROR,
@@ -155,7 +155,9 @@ def test_additional_properties_specified_as_empty_object_allowed():
 
 def test_additional_properties_not_allowed_by_default():
     schema = {"type": "object", "properties": {"oneKey": {"type": "string"}}}
-    with pytest.raises(DocumentationError, match=VALIDATE_EXCESS_RESPONSE_KEY_ERROR[:90]):
+    with pytest.raises(
+        DocumentationError, match=VALIDATE_EXCESS_KEY_ERROR.format(http_message="response", excess_key="twoKey")
+    ):
         tester.test_schema_section(schema, {"oneKey": "test", "twoKey": "test2"})
 
 


### PR DESCRIPTION
issue: https://github.com/snok/drf-openapi-tester/issues/291

# Adding `requestBody` validation support.  

Currently, the package offers the possibility of validating only the response, however, it is useful to also at the same time,e to have validated that the passed `resquestBody` in our functional tests are also properly documented and match the implementation.


## Additions/Changes

- Methods for validating request (`validate_request`) and extract the corresponding `requestBody` schema section from the OpenAPI schema (`get_request_body_schema_section`)
- Updating `test_project` to also expose `Pets` API, as it is the OpenAPI schema we have in tests.
- Adding tests for schema tester, clients and validators.
- Updating affected variables and functions.

## Notes

- Adding support **only** for `openapi` schemas (no `swagger`, previous versions), which involves `StaticSchemaLoader` and `UrlStaticSchemaLoader` instantiated with an `openapi 3.x.x`.  This because it's the current requirement I have for my project.
- Decided to make `request` validation **only** when the scenarios **has a successful** response. Why? In the case you provide for example an incomplete payload, it will always fail naturally when comparing when your schema - in this situations we should let the functional case validate that the test we chose doesn't fit our design.


## Follow Ups

- Add support for request bodies for `swagger`, `DrfSpectacularSchemaLoader` and `DrfYasgSchemaLoader`.
- Add support maybe for checking more aspects of the request? `query` params, `headers`, `authentication`, etc.